### PR TITLE
add redis_class option

### DIFF
--- a/lib/Redis/ClusterRider.pm
+++ b/lib/Redis/ClusterRider.pm
@@ -85,12 +85,13 @@ sub new {
     croak 'Specified empty list of startup nodes';
   }
 
+  $self->{redis_class} = $params{redis_class} || 'Redis';
   if ( $params{fallback} ) {
     if ( $params{lazy} ) {
       carp 'Fallback mode revokes lazy for ' . $params{startup_nodes}->[0];
     }
 
-    my $node = Redis->new(%params, server => $params{startup_nodes}->[0]);
+    my $node = $self->{redis_class}->new(%params, server => $params{startup_nodes}->[0]);
     eval { $node->cluster_info(); 1 } or return $node;
   }
 
@@ -338,7 +339,7 @@ sub _new_node {
   my $self     = shift;
   my $hostport = shift;
 
-  return Redis->new(
+  return $self->{redis_class}->new(
     %{ $self->{_node_params} },
     server    => $hostport,
     reconnect => 0.001,       # reconnect only once


### PR DESCRIPTION
added redis_class option

- redisノードのクラスを自由に設定できるオプションを追加しました
- Redis::Fastのようなクラスを指定することを想定している
- Chache::Redisでも同様にクラスを指定できる設計がされており、そちらを参考にした
- 以下のようにして任意のクラスを指定できる


↓

I have added an option to freely set the class of the redis node.
It is intended to specify a class like [Redis::Fast](https://metacpan.org/pod/Redis::Fast).
[Cache::Redis](https://metacpan.org/release/SONGMU/Cache-Redis-0.13) has a similar design that allows you to freely specify the class, which I have taken as a reference.
You can specify any class as follows:

```
use Redis::ClusterRider;
use Redis::Fast;

my $cluster = Redis::ClusterRider->new(
  redis_class => 'Redis::Fast',
  startup_nodes => [
    'localhost:7000',
    'localhost:7001',
    'localhost:7002',
  ],
);
```